### PR TITLE
feat: add step to upload test results to Codecov

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -55,3 +55,6 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true
+          files: ./junit.xml
+          flags: "python${{ matrix.python-version }}"

--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+junit.xml
 
 # Translations
 *.mo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,4 +53,4 @@ exclude = [
 ]
 
 [tool.pytest.ini_options]
-addopts = "--cov --cov-branch --cov-report=xml"
+addopts = "--cov --cov-branch --cov-report=xml --junitxml=./junit.xml"


### PR DESCRIPTION
Enhances the CI workflow by adding a step to upload test results to Codecov, ensuring better visibility into test coverage across different Python versions. Additionally, the `pyproject.toml` file is updated to include the `junitxml` option in pytest configuration for generating JUnit-style XML test reports. These changes improve test reporting and integration with Codecov.