### PR TITLE
docs: add gh pages documentation with mkdocs

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -77,3 +77,10 @@ jobs:
       - name: Publish | Upload package to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         if: steps.release.outputs.released == 'true'
+
+      - name: Publish Docksite | Upload to GitHub Pages
+        if: steps.release.outputs.released == 'true'
+        run: |
+          git config --global user.name "github-actions"
+          git config --global user.email "actions@users.noreply.github.com"
+          mkdocs gh-deploy --force --remote-branch gh-pages --remote-name origin --message "Update documentation for version ${{ steps.release.outputs.tag }}" --push

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # Pydantic Settings Doppler
+
+[![CI](https://github.com/ajauniskis/pydantic-settings-doppler/actions/workflows/test.yaml/badge.svg)](https://github.com/ajauniskis/pydantic-settings-doppler/actions/workflows/test.yaml)
 [![codecov](https://codecov.io/gh/ajauniskis/pydantic-settings-doppler/graph/badge.svg?token=XB1M3ET2H7)](https://codecov.io/gh/ajauniskis/pydantic-settings-doppler)
 [![Pydantic v2 only](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/pydantic/pydantic/main/docs/badge/v2.json)](https://docs.pydantic.dev/latest/contributing/#badges)
+[![PyPI - Implementation](https://img.shields.io/pypi/implementation/pydantic-settings-doppler)](https://pypi.org/project/pydantic-settings-doppler)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/pydantic-settings-doppler)](https://pypi.org/project/pydantic-settings-doppler)
+[![PyPI - License](https://img.shields.io/pypi/l/pydantic-settings-doppler)](https://pypi.org/project/pydantic-settings-doppler)
+![PyPI - Version](https://img.shields.io/pypi/v/pydantic-settings-doppler)
+
 
 Pydantic Settings for Doppler integration! This package provides a seamless way to load configuration values from [Doppler](https://www.doppler.com/) into your Pydantic models. It leverages the power of Doppler's secrets management and Pydantic's settings management to make your application configuration secure and easy to use.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,79 @@
+# Configuration ⚙️
+
+## Overview 🌟
+
+This document explains how to configure `pydantic-settings-doppler` to retrieve secrets from Doppler.
+
+## Environment Variables 🌍
+
+To use `DopplerSettingsSource`, you need to configure the following environment variables:
+
+- **`DOPPLER_TOKEN`**: Your Doppler access token. This is required to authenticate with the Doppler API.
+- **`DOPPLER_PROJECT_ID`**: The ID of your Doppler project. This identifies the project from which secrets will be retrieved.
+- **`DOPPLER_CONFIG_ID`**: The ID of your Doppler configuration. This specifies the configuration environment (e.g., development, staging, production).
+
+### Example ✅
+
+Set the environment variables in your shell:
+
+```bash
+export DOPPLER_TOKEN="your-doppler-access-token"
+export DOPPLER_PROJECT_ID="your-project-id"
+export DOPPLER_CONFIG_ID="your-config-id"
+```
+
+Alternatively, you can use a `.env` file:
+
+```env
+DOPPLER_TOKEN=your-doppler-access-token
+DOPPLER_PROJECT_ID=your-project-id
+DOPPLER_CONFIG_ID=your-config-id
+```
+
+## Direct Initialization 🛠️
+
+You can also pass the configuration values directly to `DopplerSettingsSource` when initializing it:
+
+```python
+from pydantic_settings_doppler import DopplerSettingsSource
+
+source = DopplerSettingsSource(
+    settings_cls=AppSettings,
+    token="your-doppler-token",
+    project_id="your-project-id",
+    config_id="your-config-id",
+)
+```
+
+## Error Handling 🚨
+
+If a required field is not found in Doppler, a `ValidationError` will be raised. Ensure all required secrets are present in your Doppler configuration.
+
+If any of config variables are not found either in environment variables on not passed in the constructor, a `SettingsError` will be raised.
+
+## Logging Configuration 📝
+
+`pydantic-settings-doppler` uses Python's `logging` module to provide debug and warning messages. To enable debug logging, configure the logger:
+
+```python
+import logging
+from pydantic_settings_doppler.logger import logger
+
+logging.basicConfig(level=logging.DEBUG)
+logger.setLevel(logging.DEBUG)
+```
+
+## Advanced Configuration 🔧
+
+### Customizing Field Names
+
+By default, `DopplerSettingsSource` uses the field name in uppercase as the key to retrieve secrets from Doppler. You can customize this behavior by setting the `alias` or `serialization_alias` attribute in your Settings model:
+
+```python
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+class AppSettings(BaseSettings):
+    db_url: str = Field(alias="DATABASE_URL")
+    api_key: str
+```

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,184 @@
+# Examples 🚀
+
+This document provides practical examples of how to use `pydantic-settings-doppler` in various scenarios.
+
+## Basic Example ✅
+
+Retrieve secrets from Doppler and integrate them into a Pydantic settings model:
+
+```python
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+from pydantic_settings_doppler import DopplerSettingsSource
+
+class AppSettings(BaseSettings):
+    database_url: str
+    api_key: str
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            DopplerSettingsSource(
+                settings_cls,
+                token="your-doppler-token",
+                project_id="your-project-id",
+                config_id="your-config-id",
+            ),
+        )
+
+# Instantiate the settings
+settings = AppSettings()
+print(settings.database_url)
+print(settings.api_key)
+```
+
+## Using Environment Variables 🌍
+
+Set the required environment variables and retrieve them using `DopplerSettingsSource`:
+
+```bash
+export DOPPLER_TOKEN="your-doppler-access-token"
+export DOPPLER_PROJECT_ID="your-project-id"
+export DOPPLER_CONFIG_ID="your-config-id"
+```
+
+```python
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+from pydantic_settings_doppler import DopplerSettingsSource
+
+class AppSettings(BaseSettings):
+    database_url: str
+    api_key: str
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            DopplerSettingsSource(settings_cls),
+        )
+
+settings = AppSettings()
+print(settings.database_url)
+print(settings.api_key)
+```
+
+## Direct Initialization ⚙️
+
+Pass Doppler configuration values directly to `DopplerSettingsSource`:
+
+```python
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+from pydantic_settings_doppler import DopplerSettingsSource
+
+class AppSettings(BaseSettings):
+    database_url: str
+    api_key: str
+
+    class Config:
+        settings_customise_sources = lambda cls: [
+            DopplerSettingsSource(
+                cls,
+                token="your-doppler-token",
+                project_id="your-project-id",
+                config_id="your-config-id",
+            ),
+            cls.env_settings_source,
+        ]
+
+settings = AppSettings()
+print(settings.database_url)
+print(settings.api_key)
+```
+
+## Error Handling Example 🚨
+
+Handle missing required fields gracefully:
+
+```python
+from pydantic import ValidationError
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+from pydantic_settings_doppler import DopplerSettingsSource
+
+class AppSettings(BaseSettings):
+    database_url: str
+    api_key: str
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            DopplerSettingsSource(settings_cls),
+        )
+
+try:
+    settings = AppSettings()
+    print(settings.database_url)
+    print(settings.api_key)
+except ValidationError as e:
+    print(f"Validation error: {e}")
+```
+
+## Logging Example 📝
+
+Enable debug logging to troubleshoot Doppler integration:
+
+```python
+import logging
+
+from pydantic_settings import BaseSettings, PydanticBaseSettingsSource
+from pydantic_settings_doppler import DopplerSettingsSource
+from pydantic_settings_doppler.logger import logger
+
+logging.basicConfig(level=logging.DEBUG)
+logger.setLevel(logging.DEBUG)
+
+
+class AppSettings(BaseSettings):
+    database_url: str
+    api_key: str
+
+    @classmethod
+    def settings_customise_sources(
+        cls,
+        settings_cls: type[BaseSettings],
+        init_settings: PydanticBaseSettingsSource,
+        env_settings: PydanticBaseSettingsSource,
+        dotenv_settings: PydanticBaseSettingsSource,
+        file_secret_settings: PydanticBaseSettingsSource,
+    ) -> tuple[PydanticBaseSettingsSource, ...]:
+        return (
+            init_settings,
+            DopplerSettingsSource(settings_cls),
+        )
+
+
+settings = AppSettings()
+print(settings.database_url)
+print(settings.api_key)
+
+```
+
+## Summary ✨
+
+These examples demonstrate how to configure and use `pydantic-settings-doppler` in various scenarios, including basic usage, environment variable integration, direct initialization, customization, error handling, and logging.

--- a/docs/img/favicon.svg
+++ b/docs/img/favicon.svg
@@ -1,0 +1,148 @@
+<svg width="101" height="100" viewBox="0 0 101 100" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M64.3092 0.259394C60.1163 -0.864113 55.8423 1.77302 54.9657 6.02449L50.9884 25.3158C48.3904 37.9168 38.5465 47.7653 25.9467 50.3692L7.02287 54.2801C2.77187 55.1586 0.13598 59.4329 1.25947 63.6258C2.38309 67.8192 6.8038 70.2029 10.9248 68.8373L29.3407 62.7351C41.5851 58.6779 55.0695 62.291 63.6448 71.9269L76.5434 86.4207C79.4289 89.6631 84.4482 89.8092 87.5174 86.74C90.5871 83.6703 90.4404 78.6501 87.1969 75.7648L72.609 62.7885C62.9468 54.1936 59.3239 40.6746 63.3932 28.3998L69.5188 9.92278C70.8847 5.80285 68.5018 1.38278 64.3092 0.259394Z" fill="url(#paint0_linear_1068_18455)"></path>
+<path d="M64.3092 0.259394C60.1163 -0.864113 55.8423 1.77302 54.9657 6.02449L50.9884 25.3158C48.3904 37.9168 38.5465 47.7653 25.9467 50.3692L7.02287 54.2801C2.77187 55.1586 0.13598 59.4329 1.25947 63.6258C2.38309 67.8192 6.8038 70.2029 10.9248 68.8373L29.3407 62.7351C41.5851 58.6779 55.0695 62.291 63.6448 71.9269L76.5434 86.4207C79.4289 89.6631 84.4482 89.8092 87.5174 86.74C90.5871 83.6703 90.4404 78.6501 87.1969 75.7648L72.609 62.7885C62.9468 54.1936 59.3239 40.6746 63.3932 28.3998L69.5188 9.92278C70.8847 5.80285 68.5018 1.38278 64.3092 0.259394Z" fill="url(#paint1_linear_1068_18455)" fill-opacity="0.46"></path>
+<path d="M64.3092 0.259394C60.1163 -0.864113 55.8423 1.77302 54.9657 6.02449L50.9884 25.3158C48.3904 37.9168 38.5465 47.7653 25.9467 50.3692L7.02287 54.2801C2.77187 55.1586 0.13598 59.4329 1.25947 63.6258C2.38309 67.8192 6.8038 70.2029 10.9248 68.8373L29.3407 62.7351C41.5851 58.6779 55.0695 62.291 63.6448 71.9269L76.5434 86.4207C79.4289 89.6631 84.4482 89.8092 87.5174 86.74C90.5871 83.6703 90.4404 78.6501 87.1969 75.7648L72.609 62.7885C62.9468 54.1936 59.3239 40.6746 63.3932 28.3998L69.5188 9.92278C70.8847 5.80285 68.5018 1.38278 64.3092 0.259394Z" fill="url(#paint2_linear_1068_18455)" fill-opacity="0.66"></path>
+<path d="M64.3092 0.259394C60.1163 -0.864113 55.8423 1.77302 54.9657 6.02449L50.9884 25.3158C48.3904 37.9168 38.5465 47.7653 25.9467 50.3692L7.02287 54.2801C2.77187 55.1586 0.13598 59.4329 1.25947 63.6258C2.38309 67.8192 6.8038 70.2029 10.9248 68.8373L29.3407 62.7351C41.5851 58.6779 55.0695 62.291 63.6448 71.9269L76.5434 86.4207C79.4289 89.6631 84.4482 89.8092 87.5174 86.74C90.5871 83.6703 90.4404 78.6501 87.1969 75.7648L72.609 62.7885C62.9468 54.1936 59.3239 40.6746 63.3932 28.3998L69.5188 9.92278C70.8847 5.80285 68.5018 1.38278 64.3092 0.259394Z" fill="url(#paint3_linear_1068_18455)" fill-opacity="0.67"></path>
+<path d="M64.3092 0.259394C60.1163 -0.864113 55.8423 1.77302 54.9657 6.02449L50.9884 25.3158C48.3904 37.9168 38.5465 47.7653 25.9467 50.3692L7.02287 54.2801C2.77187 55.1586 0.13598 59.4329 1.25947 63.6258C2.38309 67.8192 6.8038 70.2029 10.9248 68.8373L29.3407 62.7351C41.5851 58.6779 55.0695 62.291 63.6448 71.9269L76.5434 86.4207C79.4289 89.6631 84.4482 89.8092 87.5174 86.74C90.5871 83.6703 90.4404 78.6501 87.1969 75.7648L72.609 62.7885C62.9468 54.1936 59.3239 40.6746 63.3932 28.3998L69.5188 9.92278C70.8847 5.80285 68.5018 1.38278 64.3092 0.259394Z" fill="url(#paint4_linear_1068_18455)"></path>
+<path d="M64.3092 0.259394C60.1163 -0.864113 55.8423 1.77302 54.9657 6.02449L50.9884 25.3158C48.3904 37.9168 38.5465 47.7653 25.9467 50.3692L7.02287 54.2801C2.77187 55.1586 0.13598 59.4329 1.25947 63.6258C2.38309 67.8192 6.8038 70.2029 10.9248 68.8373L29.3407 62.7351C41.5851 58.6779 55.0695 62.291 63.6448 71.9269L76.5434 86.4207C79.4289 89.6631 84.4482 89.8092 87.5174 86.74C90.5871 83.6703 90.4404 78.6501 87.1969 75.7648L72.609 62.7885C62.9468 54.1936 59.3239 40.6746 63.3932 28.3998L69.5188 9.92278C70.8847 5.80285 68.5018 1.38278 64.3092 0.259394Z" fill="url(#paint5_radial_1068_18455)" fill-opacity="0.94"></path>
+<path d="M64.3092 0.259394C60.1163 -0.864113 55.8423 1.77302 54.9657 6.02449L50.9884 25.3158C48.3904 37.9168 38.5465 47.7653 25.9467 50.3692L7.02287 54.2801C2.77187 55.1586 0.13598 59.4329 1.25947 63.6258C2.38309 67.8192 6.8038 70.2029 10.9248 68.8373L29.3407 62.7351C41.5851 58.6779 55.0695 62.291 63.6448 71.9269L76.5434 86.4207C79.4289 89.6631 84.4482 89.8092 87.5174 86.74C90.5871 83.6703 90.4404 78.6501 87.1969 75.7648L72.609 62.7885C62.9468 54.1936 59.3239 40.6746 63.3932 28.3998L69.5188 9.92278C70.8847 5.80285 68.5018 1.38278 64.3092 0.259394Z" fill="url(#paint6_radial_1068_18455)" fill-opacity="0.1"></path>
+<path d="M14.1852 24.3911C10.7562 21.2887 10.6228 15.9476 13.8926 12.6779C17.1623 9.40812 22.5033 9.54156 25.6057 12.9705L35.3591 23.7506C37.99 26.6584 37.8785 31.1183 35.1058 33.8911C32.333 36.6639 27.873 36.7753 24.9653 34.1444L14.1852 24.3911Z" fill="url(#paint7_linear_1068_18455)"></path>
+<path d="M14.1852 24.3911C10.7562 21.2887 10.6228 15.9476 13.8926 12.6779C17.1623 9.40812 22.5033 9.54156 25.6057 12.9705L35.3591 23.7506C37.99 26.6584 37.8785 31.1183 35.1058 33.8911C32.333 36.6639 27.873 36.7753 24.9653 34.1444L14.1852 24.3911Z" fill="url(#paint8_linear_1068_18455)" fill-opacity="0.46"></path>
+<path d="M14.1852 24.3911C10.7562 21.2887 10.6228 15.9476 13.8926 12.6779C17.1623 9.40812 22.5033 9.54156 25.6057 12.9705L35.3591 23.7506C37.99 26.6584 37.8785 31.1183 35.1058 33.8911C32.333 36.6639 27.873 36.7753 24.9653 34.1444L14.1852 24.3911Z" fill="url(#paint9_linear_1068_18455)" fill-opacity="0.66"></path>
+<path d="M14.1852 24.3911C10.7562 21.2887 10.6228 15.9476 13.8926 12.6779C17.1623 9.40812 22.5033 9.54156 25.6057 12.9705L35.3591 23.7506C37.99 26.6584 37.8785 31.1183 35.1058 33.8911C32.333 36.6639 27.873 36.7753 24.9653 34.1444L14.1852 24.3911Z" fill="url(#paint10_linear_1068_18455)" fill-opacity="0.67"></path>
+<path d="M14.1852 24.3911C10.7562 21.2887 10.6228 15.9476 13.8926 12.6779C17.1623 9.40812 22.5033 9.54156 25.6057 12.9705L35.3591 23.7506C37.99 26.6584 37.8785 31.1183 35.1058 33.8911C32.333 36.6639 27.873 36.7753 24.9653 34.1444L14.1852 24.3911Z" fill="url(#paint11_linear_1068_18455)"></path>
+<path d="M14.1852 24.3911C10.7562 21.2887 10.6228 15.9476 13.8926 12.6779C17.1623 9.40812 22.5033 9.54156 25.6057 12.9705L35.3591 23.7506C37.99 26.6584 37.8785 31.1183 35.1058 33.8911C32.333 36.6639 27.873 36.7753 24.9653 34.1444L14.1852 24.3911Z" fill="url(#paint12_radial_1068_18455)" fill-opacity="0.94"></path>
+<path d="M14.1852 24.3911C10.7562 21.2887 10.6228 15.9476 13.8926 12.6779C17.1623 9.40812 22.5033 9.54156 25.6057 12.9705L35.3591 23.7506C37.99 26.6584 37.8785 31.1183 35.1058 33.8911C32.333 36.6639 27.873 36.7753 24.9653 34.1444L14.1852 24.3911Z" fill="url(#paint13_radial_1068_18455)" fill-opacity="0.1"></path>
+<path d="M90.0279 30.3514C94.4292 28.933 99.1214 31.488 100.318 35.9545C101.515 40.4211 98.7289 44.9798 94.2081 45.9521L79.9957 49.0088C76.162 49.8333 72.3553 47.5068 71.3404 43.7191C70.3255 39.9314 72.459 36.0133 76.1912 34.8105L90.0279 30.3514Z" fill="url(#paint14_linear_1068_18455)"></path>
+<path d="M90.0279 30.3514C94.4292 28.933 99.1214 31.488 100.318 35.9545C101.515 40.4211 98.7289 44.9798 94.2081 45.9521L79.9957 49.0088C76.162 49.8333 72.3553 47.5068 71.3404 43.7191C70.3255 39.9314 72.459 36.0133 76.1912 34.8105L90.0279 30.3514Z" fill="url(#paint15_linear_1068_18455)" fill-opacity="0.46"></path>
+<path d="M90.0279 30.3514C94.4292 28.933 99.1214 31.488 100.318 35.9545C101.515 40.4211 98.7289 44.9798 94.2081 45.9521L79.9957 49.0088C76.162 49.8333 72.3553 47.5068 71.3404 43.7191C70.3255 39.9314 72.459 36.0133 76.1912 34.8105L90.0279 30.3514Z" fill="url(#paint16_linear_1068_18455)" fill-opacity="0.66"></path>
+<path d="M90.0279 30.3514C94.4292 28.933 99.1214 31.488 100.318 35.9545C101.515 40.4211 98.7289 44.9798 94.2081 45.9521L79.9957 49.0088C76.162 49.8333 72.3553 47.5068 71.3404 43.7191C70.3255 39.9314 72.459 36.0133 76.1912 34.8105L90.0279 30.3514Z" fill="url(#paint17_linear_1068_18455)" fill-opacity="0.67"></path>
+<path d="M90.0279 30.3514C94.4292 28.933 99.1214 31.488 100.318 35.9545C101.515 40.4211 98.7289 44.9798 94.2081 45.9521L79.9957 49.0088C76.162 49.8333 72.3553 47.5068 71.3404 43.7191C70.3255 39.9314 72.459 36.0133 76.1912 34.8105L90.0279 30.3514Z" fill="url(#paint18_linear_1068_18455)"></path>
+<path d="M90.0279 30.3514C94.4292 28.933 99.1214 31.488 100.318 35.9545C101.515 40.4211 98.7289 44.9798 94.2081 45.9521L79.9957 49.0088C76.162 49.8333 72.3553 47.5068 71.3404 43.7191C70.3255 39.9314 72.459 36.0133 76.1912 34.8105L90.0279 30.3514Z" fill="url(#paint19_radial_1068_18455)" fill-opacity="0.94"></path>
+<path d="M90.0279 30.3514C94.4292 28.933 99.1214 31.488 100.318 35.9545C101.515 40.4211 98.7289 44.9798 94.2081 45.9521L79.9957 49.0088C76.162 49.8333 72.3553 47.5068 71.3404 43.7191C70.3255 39.9314 72.459 36.0133 76.1912 34.8105L90.0279 30.3514Z" fill="url(#paint20_radial_1068_18455)" fill-opacity="0.1"></path>
+<path d="M46.5794 93.3443C45.6071 97.8651 41.0484 100.651 36.5818 99.4544C32.1152 98.2575 29.5603 93.5654 30.9786 89.1641L35.4378 75.3274C36.6405 71.5952 40.5587 69.4617 44.3464 70.4766C48.134 71.4915 50.4605 75.2982 49.636 79.1318L46.5794 93.3443Z" fill="url(#paint21_linear_1068_18455)"></path>
+<path d="M46.5794 93.3443C45.6071 97.8651 41.0484 100.651 36.5818 99.4544C32.1152 98.2575 29.5603 93.5654 30.9786 89.1641L35.4378 75.3274C36.6405 71.5952 40.5587 69.4617 44.3464 70.4766C48.134 71.4915 50.4605 75.2982 49.636 79.1318L46.5794 93.3443Z" fill="url(#paint22_linear_1068_18455)" fill-opacity="0.46"></path>
+<path d="M46.5794 93.3443C45.6071 97.8651 41.0484 100.651 36.5818 99.4544C32.1152 98.2575 29.5603 93.5654 30.9786 89.1641L35.4378 75.3274C36.6405 71.5952 40.5587 69.4617 44.3464 70.4766C48.134 71.4915 50.4605 75.2982 49.636 79.1318L46.5794 93.3443Z" fill="url(#paint23_linear_1068_18455)" fill-opacity="0.66"></path>
+<path d="M46.5794 93.3443C45.6071 97.8651 41.0484 100.651 36.5818 99.4544C32.1152 98.2575 29.5603 93.5654 30.9786 89.1641L35.4378 75.3274C36.6405 71.5952 40.5587 69.4617 44.3464 70.4766C48.134 71.4915 50.4605 75.2982 49.636 79.1318L46.5794 93.3443Z" fill="url(#paint24_linear_1068_18455)" fill-opacity="0.67"></path>
+<path d="M46.5794 93.3443C45.6071 97.8651 41.0484 100.651 36.5818 99.4544C32.1152 98.2575 29.5603 93.5654 30.9786 89.1641L35.4378 75.3274C36.6405 71.5952 40.5587 69.4617 44.3464 70.4766C48.134 71.4915 50.4605 75.2982 49.636 79.1318L46.5794 93.3443Z" fill="url(#paint25_linear_1068_18455)"></path>
+<path d="M46.5794 93.3443C45.6071 97.8651 41.0484 100.651 36.5818 99.4544C32.1152 98.2575 29.5603 93.5654 30.9786 89.1641L35.4378 75.3274C36.6405 71.5952 40.5587 69.4617 44.3464 70.4766C48.134 71.4915 50.4605 75.2982 49.636 79.1318L46.5794 93.3443Z" fill="url(#paint26_radial_1068_18455)" fill-opacity="0.94"></path>
+<path d="M46.5794 93.3443C45.6071 97.8651 41.0484 100.651 36.5818 99.4544C32.1152 98.2575 29.5603 93.5654 30.9786 89.1641L35.4378 75.3274C36.6405 71.5952 40.5587 69.4617 44.3464 70.4766C48.134 71.4915 50.4605 75.2982 49.636 79.1318L46.5794 93.3443Z" fill="url(#paint27_radial_1068_18455)" fill-opacity="0.1"></path>
+<defs>
+<linearGradient id="paint0_linear_1068_18455" x1="7.23327" y1="62.3326" x2="48.1235" y2="30.169" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="0.422647" stop-color="#F55C15" stop-opacity="0.84"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint1_linear_1068_18455" x1="55.6034" y1="45.8768" x2="41.1422" y2="93.9976" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A73394" stop-opacity="0"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint2_linear_1068_18455" x1="84.0271" y1="87.0164" x2="39.3969" y2="54.6034" gradientUnits="userSpaceOnUse">
+<stop offset="0.385417" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E2606E" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint3_linear_1068_18455" x1="25.9331" y1="4.73728" x2="29.9223" y2="37.8983" gradientUnits="userSpaceOnUse">
+<stop offset="0.182292" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#CB4758" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint4_linear_1068_18455" x1="64.5793" y1="35.9036" x2="37.6516" y2="52.3594" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E46373" stop-opacity="0"></stop>
+</linearGradient>
+<radialGradient id="paint5_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(38.6489 53.1074) rotate(176.204) scale(52.7244 138.365)">
+<stop stop-color="#F55C15" stop-opacity="0.46"></stop>
+<stop offset="0.831969" stop-color="#EE82C6" stop-opacity="0"></stop>
+</radialGradient>
+<radialGradient id="paint6_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1.49331 68.0673) rotate(-19.7843) scale(36.8309 36.7807)">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="1" stop-color="#DD5A68" stop-opacity="0"></stop>
+</radialGradient>
+<linearGradient id="paint7_linear_1068_18455" x1="7.23327" y1="62.3326" x2="48.1235" y2="30.169" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="0.422647" stop-color="#F55C15" stop-opacity="0.84"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint8_linear_1068_18455" x1="55.6034" y1="45.8768" x2="41.1422" y2="93.9976" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A73394" stop-opacity="0"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint9_linear_1068_18455" x1="84.0271" y1="87.0164" x2="39.3969" y2="54.6034" gradientUnits="userSpaceOnUse">
+<stop offset="0.385417" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E2606E" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint10_linear_1068_18455" x1="25.9331" y1="4.73728" x2="29.9223" y2="37.8983" gradientUnits="userSpaceOnUse">
+<stop offset="0.182292" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#CB4758" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint11_linear_1068_18455" x1="64.5793" y1="35.9036" x2="37.6516" y2="52.3594" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E46373" stop-opacity="0"></stop>
+</linearGradient>
+<radialGradient id="paint12_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(38.6489 53.1074) rotate(176.204) scale(52.7244 138.365)">
+<stop stop-color="#F55C15" stop-opacity="0.46"></stop>
+<stop offset="0.831969" stop-color="#EE82C6" stop-opacity="0"></stop>
+</radialGradient>
+<radialGradient id="paint13_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1.49331 68.0673) rotate(-19.7843) scale(36.8309 36.7807)">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="1" stop-color="#DD5A68" stop-opacity="0"></stop>
+</radialGradient>
+<linearGradient id="paint14_linear_1068_18455" x1="7.23327" y1="62.3326" x2="48.1235" y2="30.169" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="0.422647" stop-color="#F55C15" stop-opacity="0.84"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint15_linear_1068_18455" x1="55.6034" y1="45.8768" x2="41.1422" y2="93.9976" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A73394" stop-opacity="0"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint16_linear_1068_18455" x1="84.0271" y1="87.0164" x2="39.3969" y2="54.6034" gradientUnits="userSpaceOnUse">
+<stop offset="0.385417" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E2606E" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint17_linear_1068_18455" x1="25.9331" y1="4.73728" x2="29.9223" y2="37.8983" gradientUnits="userSpaceOnUse">
+<stop offset="0.182292" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#CB4758" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint18_linear_1068_18455" x1="64.5793" y1="35.9036" x2="37.6516" y2="52.3594" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E46373" stop-opacity="0"></stop>
+</linearGradient>
+<radialGradient id="paint19_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(38.6489 53.1074) rotate(176.204) scale(52.7244 138.365)">
+<stop stop-color="#F55C15" stop-opacity="0.46"></stop>
+<stop offset="0.831969" stop-color="#EE82C6" stop-opacity="0"></stop>
+</radialGradient>
+<radialGradient id="paint20_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1.49331 68.0673) rotate(-19.7843) scale(36.8309 36.7807)">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="1" stop-color="#DD5A68" stop-opacity="0"></stop>
+</radialGradient>
+<linearGradient id="paint21_linear_1068_18455" x1="7.23327" y1="62.3326" x2="48.1235" y2="30.169" gradientUnits="userSpaceOnUse">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="0.422647" stop-color="#F55C15" stop-opacity="0.84"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint22_linear_1068_18455" x1="55.6034" y1="45.8768" x2="41.1422" y2="93.9976" gradientUnits="userSpaceOnUse">
+<stop stop-color="#A73394" stop-opacity="0"></stop>
+<stop offset="1" stop-color="#6B13F5"></stop>
+</linearGradient>
+<linearGradient id="paint23_linear_1068_18455" x1="84.0271" y1="87.0164" x2="39.3969" y2="54.6034" gradientUnits="userSpaceOnUse">
+<stop offset="0.385417" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E2606E" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint24_linear_1068_18455" x1="25.9331" y1="4.73728" x2="29.9223" y2="37.8983" gradientUnits="userSpaceOnUse">
+<stop offset="0.182292" stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#CB4758" stop-opacity="0"></stop>
+</linearGradient>
+<linearGradient id="paint25_linear_1068_18455" x1="64.5793" y1="35.9036" x2="37.6516" y2="52.3594" gradientUnits="userSpaceOnUse">
+<stop stop-color="#6B13F5"></stop>
+<stop offset="1" stop-color="#E46373" stop-opacity="0"></stop>
+</linearGradient>
+<radialGradient id="paint26_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(38.6489 53.1074) rotate(176.204) scale(52.7244 138.365)">
+<stop stop-color="#F55C15" stop-opacity="0.46"></stop>
+<stop offset="0.831969" stop-color="#EE82C6" stop-opacity="0"></stop>
+</radialGradient>
+<radialGradient id="paint27_radial_1068_18455" cx="0" cy="0" r="1" gradientUnits="userSpaceOnUse" gradientTransform="translate(-1.49331 68.0673) rotate(-19.7843) scale(36.8309 36.7807)">
+<stop stop-color="#FF9EFA"></stop>
+<stop offset="1" stop-color="#DD5A68" stop-opacity="0"></stop>
+</radialGradient>
+</defs>
+</svg>

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+/home/srv/Documents/pydantic-settings-doppler/README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,81 @@
+site_name: Pydantic Settings Doppler
+site_description: Doppler for Pydantic Settings
+repo_url: https://github.com/ajauniskis/pydantic-settings-doppler
+site_url: https://ajauniskis.github.io/pydantic-settings-doppler
+
+nav:
+  - Docs: index.md
+  - Configuration: configuration.md
+  - Examples: examples.md
+
+theme:
+  name: material
+  icon:
+    repo: fontawesome/brands/github
+    edit: material/pencil
+    view: material/eye
+  features:
+    - content.action.edit
+    - content.code.annotate
+    - content.code.copy
+    - content.code.select
+    - header.autohide
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.path
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
+  favicon: img/favicon.svg
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+
+markdown_extensions:
+  - admonition
+  - attr_list
+  - toc:
+      permalink: true
+  - tables
+  - pymdownx.emoji
+  - pymdownx.highlight:
+      linenums: true
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.superfences
+  - pymdownx.snippets
+  - pymdownx.tabbed
+
+extra:
+  pymdownx:
+    highlight:
+      linenums: true
+      guess_lang: false
+    superfences:
+      custom_fences:
+        - name: python
+          class: highlight-python
+          language: python
+
+plugins:
+  - mkdocstrings
+  - search
+  - git-committers:
+      repository: ajauniskis/pydantic-settings-doppler
+      branch: main

--- a/poetry.lock
+++ b/poetry.lock
@@ -1754,4 +1754,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9"
-content-hash = "9e781a8594e27af234b6a1fa25f7f8f29e0b1ccdc2d332a3fabab16c2c155edd"
+content-hash = "461967da1724c7f26c674f1be68beb09dce8d16ad9457e0b087d9fc0e5586236"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "doppler-sdk (>=1.3.0,<2.0.0)"
 ]
 classifiers = [
-    'Development Status :: 3 - Alpha',
+    'Development Status :: 3 - Beta',
     'Programming Language :: Python',
     'Programming Language :: Python :: 3',
     'Programming Language :: Python :: 3 :: Only',
@@ -23,6 +23,7 @@ classifiers = [
     'Programming Language :: Python :: 3.11',
     'Programming Language :: Python :: 3.12',
     'Programming Language :: Python :: 3.13',
+    'Programming Language :: Python :: Implementation :: CPython',
     'Intended Audience :: Developers',
     'Intended Audience :: Information Technology',
     'Intended Audience :: System Administrators',
@@ -34,11 +35,16 @@ classifiers = [
     'Environment :: Console',
     'Topic :: Software Development :: Libraries :: Python Modules',
     'Topic :: Internet',
+    'Topic :: Utilities',
+    'Typing :: Typed',
+    'Framework :: Pydantic',
+    'Framework :: FastAPI',
+    'Natural Language :: English',
 ]
 
 [project.urls]
 Homepage = "https://github.com/ajauniskis/pydantic-settings-doppler"
-# Documentation = ""
+Documentation = "https://ajauniskis.github.io/pydantic-settings-doppler"
 Repository = "https://github.com/ajauniskis/pydantic-settings-doppler"
 Changelog = "https://github.com/ajauniskis/pydantic-settings-doppler/blob/main/CHANGELOG.md"
 "Bug Tracker" = "https://github.com/ajauniskis/pydantic-settings-doppler/issues"
@@ -87,6 +93,7 @@ mkdocs = "^1.6.1"
 mkdocstrings = {extras = ["python"], version = "^0.29.1"}
 mkdocs-material = "^9.6.11"
 mkdocs-git-committers-plugin = "^0.2.3"
+pymdown-extensions = "^10.14.3"
 
 [tool.bandit]
 exclude_dirs = ["venv", "env", ".venv", "tests"]


### PR DESCRIPTION
Enhances the project by integrating GitHub Pages deployment for documentation using MkDocs. It updates the workflow to publish documentation on successful releases, improves project metadata in `pyproject.toml`, and adds badges to the README for better visibility. Additionally, new documentation files and configurations have been introduced to improve user guidance.